### PR TITLE
Fix tags

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,5 +1,0 @@
-[user]
-	email = clovis@synapse-medicine.com
-	name = clovis
-[credential]
-	helper = "!f() { /pleroma/.vscode-server/bin/2d23c42a936db1c7b3b06f918cde29561cc47cd6/node /tmp/vscode-remote-containers-2567caaec42ef55e3b5284e04ef2517306eb2a7f.js $*; }; f"

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,5 @@
+[user]
+	email = clovis@synapse-medicine.com
+	name = clovis
+[credential]
+	helper = "!f() { /pleroma/.vscode-server/bin/2d23c42a936db1c7b3b06f918cde29561cc47cd6/node /tmp/vscode-remote-containers-2567caaec42ef55e3b5284e04ef2517306eb2a7f.js $*; }; f"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 # App artifacts
+.vscode-server
+.cache
+.hex
+.mix
 /_build
 /db
 /deps

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .cache
 .hex
 .mix
+.gitconfig
 /_build
 /db
 /deps

--- a/lib/pleroma/formatter.ex
+++ b/lib/pleroma/formatter.ex
@@ -7,7 +7,7 @@ defmodule Pleroma.Formatter do
   alias Pleroma.User
 
   @safe_mention_regex ~r/^(\s*(?<mentions>(@.+?\s+){1,})+)(?<rest>.*)/s
-  @tag_regex ~r/(?<tag>\#[[:word:]_]*[[:alpha:]_·][[:word:]_·\p{M}]*)/
+  @tag_regex ~r/(?>^|\s)(\#(?>[A-Za-z0-9])+)(?>$|\s)/
   @link_regex ~r"((?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~%:/?#[\]@!\$&'\(\)\*\+,;=.]+)|[0-9a-z+\-\.]+:[0-9a-z$-_.+!*'(),]+"ui
   @markdown_characters_regex ~r/(`|\*|_|{|}|[|]|\(|\)|#|\+|-|\.|!)/
 

--- a/lib/pleroma/formatter.ex
+++ b/lib/pleroma/formatter.ex
@@ -7,6 +7,7 @@ defmodule Pleroma.Formatter do
   alias Pleroma.User
 
   @safe_mention_regex ~r/^(\s*(?<mentions>(@.+?\s+){1,})+)(?<rest>.*)/s
+  @tag_regex ~r/(?<tag>\#[[:word:]_]*[[:alpha:]_·][[:word:]_·\p{M}]*)/
   @link_regex ~r"((?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~%:/?#[\]@!\$&'\(\)\*\+,;=.]+)|[0-9a-z+\-\.]+:[0-9a-z$-_.+!*'(),]+"ui
   @markdown_characters_regex ~r/(`|\*|_|{|}|[|]|\(|\)|#|\+|-|\.|!)/
 
@@ -122,6 +123,8 @@ defmodule Pleroma.Formatter do
   end
 
   def markdown_to_html(text) do
+    #inserting spaces before and after tag to avoid a bug in Pleroma's Linkify
+    text = Regex.replace(@tag_regex, text, " \\1 ")
     Earmark.as_html!(text, %Earmark.Options{compact_output: true})
   end
 

--- a/test/pleroma/web/common_api/utils_test.exs
+++ b/test/pleroma/web/common_api/utils_test.exs
@@ -100,8 +100,8 @@ defmodule Pleroma.Web.CommonAPI.UtilsTest do
 
     test "works for bare text/markdown" do
 
-      text = "#test\n\nbonjour #tag\n\n#bye"
-      expected = "<p> <a class=\"hashtag\" data-tag=\"test\" href=\"http://localhost:4001/tag/test\">#test</a> </p><p>bonjour  <a class=\"hashtag\" data-tag=\"tag\" href=\"http://localhost:4001/tag/tag\">#tag</a> </p><p> <a class=\"hashtag\" data-tag=\"bye\" href=\"http://localhost:4001/tag/bye\">#bye</a> </p>"
+      text = "#test\n\nbonjour #tag\n\n#tag#second @mention#tag\n\n#bye"
+      expected = "<p> <a class=\"hashtag\" data-tag=\"test\" href=\"http://localhost:4001/tag/test\">#test</a> \nbonjour <a class=\"hashtag\" data-tag=\"tag\" href=\"http://localhost:4001/tag/tag\">#tag</a> \n<a class=\"hashtag\" data-tag=\"tag\" href=\"http://localhost:4001/tag/tag\">#tag</a>#second @mention#tag\n <a class=\"hashtag\" data-tag=\"bye\" href=\"http://localhost:4001/tag/bye\">#bye</a> </p>"
 
       {output, _, _} = Utils.format_input(text, "text/markdown")
 

--- a/test/pleroma/web/common_api/utils_test.exs
+++ b/test/pleroma/web/common_api/utils_test.exs
@@ -99,6 +99,15 @@ defmodule Pleroma.Web.CommonAPI.UtilsTest do
     end
 
     test "works for bare text/markdown" do
+
+      text = "#test\n\nbonjour #tag\n\n#bye"
+      expected = "<p> <a class=\"hashtag\" data-tag=\"test\" href=\"http://localhost:4001/tag/test\">#test</a> </p><p>bonjour  <a class=\"hashtag\" data-tag=\"tag\" href=\"http://localhost:4001/tag/tag\">#tag</a> </p><p> <a class=\"hashtag\" data-tag=\"bye\" href=\"http://localhost:4001/tag/bye\">#bye</a> </p>"
+
+      {output, _, _} = Utils.format_input(text, "text/markdown")
+
+      assert output == expected
+
+
       text = "**hello world**"
       expected = "<p><strong>hello world</strong></p>"
 


### PR DESCRIPTION
Ajout d'un workaround étant donné la problématique trop complexe posée par l'édition de la librairie Pleroma Linkify. 

Ajout d'espace de part et d'autre des tags lors de la conversion markdown vers HTML.

Fix https://github.com/Cl0v1s/bdx.town/issues/1